### PR TITLE
adding bindThis option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.7
+
+- Adds `bindThis` option for bind global to this on the scope of the iife
+
 ## 0.0.5
 
 - Adds `trimCode` option for removing leading and trailing whitespace

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can configure the following options:
 - `useStrict`: a boolean indicating whether to prepend a `"use strict";` directive (`true` by default)
 - `trimCode`: a boolean indicating whether to remove leading & trailing whitespace from the code (`true` by default)
 - `prependSemicolon`: a boolean indicating whether to prepend a semicolon as statement terminator before the IIFE (`true` by default)
+- `bindThis`: a boolean indicating whether to prepend `.bind(this)` to the IIFE (`false` by default)
 
 ```js
 var gulp = require("gulp");

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Stream = require("stream");
 function gulpIife(userOptions) {
     "use strict";
 
-    var defaultOptions = { useStrict: true, trimCode: true, prependSemicolon: true };
+    var defaultOptions = { useStrict: true, trimCode: true, prependSemicolon: true, bindThis: false };
     var options = _.merge({}, defaultOptions, userOptions);
 
     var stream = new Stream.Transform({ objectMode: true });
@@ -22,9 +22,10 @@ function gulpIife(userOptions) {
 }
 
 function surroundWithIife(code, options) {
-    var leadingCode = "(function() {\n",
+    var bindThis = options.bindThis ? '.bind(this)' : '';
+        leadingCode = "(function() {\n",
         trimmedCode = options.trimCode ? code.trim() : code,
-        trailingCode = "\n}());\n";
+        trailingCode = "\n}" + bindThis + "());\n";
 
     if (options.prependSemicolon) {
        leadingCode = ";" + leadingCode;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-iife",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Wraps JavaScript code within an immediately invoked function expression.",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Some libs needs to have the `this` bound to the global (`window`) object. When we are on the strict mode it does not.

This commit add an option to workaround this problem binding the global `this` to the body of the IIFE.