### PR TITLE
Add basic sourcemap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Wraps JavaScript code within an immediately invoked function expression.",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": ["lib/"],
+  "files": [
+    "lib/"
+  ],
   "scripts": {
     "prepublish": "npm test && gulp transpile",
     "test": "mocha test/transpiled",
@@ -31,7 +33,9 @@
   "homepage": "https://github.com/mariusschulz/gulp-iife",
   "dependencies": {
     "lodash": "^3.6.0",
-    "through2": "^2.0.0"
+    "source-map": "^0.5.3",
+    "through2": "^2.0.0",
+    "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {
     "babel": "^6.0.15",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,23 @@
 var through = require("through2");
+var applySourceMap = require('vinyl-sourcemaps-apply');
 var iife = require("./iife");
 
 module.exports = function gulpIife(userOptions) {
     return through.obj(function(file, encoding, callback) {
-        const contents = String(file.contents);
-        const wrappedContents = iife.surround(contents, userOptions);
+        let contents = String(file.contents);
 
-        file.contents = Buffer(wrappedContents);
+        if (file.sourceMap) {
+            userOptions = userOptions || {};
+            userOptions.generateSourceMap = true;
+            userOptions.fileName = file.relative;
+        }
+
+        let result = iife.surround(contents, userOptions);
+        file.contents = Buffer(result.code);
+
+        if (file.sourceMap) {
+            applySourceMap(file, result.sourceMap);
+        }
 
         callback(null, file);
     });

--- a/test/src/iife.js
+++ b/test/src/iife.js
@@ -1,5 +1,6 @@
 var assert = require("chai").assert;
 var iife = require("../../lib/iife");
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
 
 describe("IIFE", function() {
     var code = "var x = 1;\n\n";
@@ -9,8 +10,8 @@ describe("IIFE", function() {
             assert.typeOf(iife.surround, "function");
         });
 
-        it("should return a string", function() {
-            assert.typeOf(iife.surround(""), "string");
+        it("should return an object with a string", function() {
+            assert.typeOf(iife.surround("").code, "string");
         });
 
         it("should apply the correct defaults", function() {
@@ -21,7 +22,29 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code), expected);
+            assert.equal(iife.surround(code).code, expected);
+        });
+
+        it("should generate correct sourcemaps for default options", function() {
+            var fileName = "main.js";
+            var options = {generateSourceMap: true, fileName: fileName};
+            var result = iife.surround(code, options);
+
+            var expectedMap = new SourceMapGenerator({file: fileName});
+
+            expectedMap.addMapping({
+                source: fileName,
+                original: {
+                    line: 1,
+                    column: 0
+                },
+                generated: {
+                    line: 4,
+                    column: 0
+                }
+            });
+
+            assert.equal(result.sourceMap, expectedMap.toString());
         });
 
         it("should add a \"use strict\" directive when \"useStrict\" is true", function() {
@@ -32,7 +55,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { useStrict: true }), expected);
+            assert.equal(iife.surround(code, { useStrict: true }).code, expected);
         });
 
         it("should not add a \"use strict\" directive when \"useStrict\" is false", function() {
@@ -41,7 +64,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { useStrict: false }), expected);
+            assert.equal(iife.surround(code, { useStrict: false }).code, expected);
         });
 
         it("should trim the code when \"trimCode\" is true", function() {
@@ -52,7 +75,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { trimCode: true }), expected);
+            assert.equal(iife.surround(code, { trimCode: true }).code, expected);
         });
 
         it("should not trim the code when \"trimCode\" is false", function() {
@@ -65,7 +88,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { trimCode: false }), expected);
+            assert.equal(iife.surround(code, { trimCode: false }).code, expected);
         });
 
         it("should prepend a semicolon when \"prependSemicolon\" is true", function() {
@@ -76,7 +99,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { prependSemicolon: true }), expected);
+            assert.equal(iife.surround(code, { prependSemicolon: true }).code, expected);
         });
 
         it("should not prepend a semicolon when \"prependSemicolon\" is false", function() {
@@ -87,7 +110,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { prependSemicolon: false }), expected);
+            assert.equal(iife.surround(code, { prependSemicolon: false }).code, expected);
         });
 
         it("should add \".bind(this)\" when \"bindThis\" is true", function() {
@@ -98,7 +121,7 @@ var x = 1;
 }.bind(this)());
 `;
 
-            assert.equal(iife.surround(code, { bindThis: true }), expected);
+            assert.equal(iife.surround(code, { bindThis: true }).code, expected);
         });
 
         it("should not add \".bind(this)\" when \"bindThis\" is false", function() {
@@ -109,7 +132,7 @@ var x = 1;
 }());
 `;
 
-            assert.equal(iife.surround(code, { bindThis: false }), expected);
+            assert.equal(iife.surround(code, { bindThis: false }).code, expected);
         });
 
         it("should add the arguments and parameters specified in \"args\" and \"params\"", function() {
@@ -125,7 +148,7 @@ var x = 1;
                 params: ["$", "undefined"]
             };
 
-            assert.equal(iife.surround(code, options), expected);
+            assert.equal(iife.surround(code, options).code, expected);
         });
 
         it("should use \"params\" values for \"args\" if \"args\" is missing", function() {
@@ -140,7 +163,7 @@ var x = 1;
                 params: ["window"]
             };
 
-            assert.equal(iife.surround(code, options), expected);
+            assert.equal(iife.surround(code, options).code, expected);
         });
 
         it("should use \"args\" values for \"params\" if \"params\" is missing", function() {
@@ -155,7 +178,7 @@ var x = 1;
                 args: ["window"]
             };
 
-            assert.equal(iife.surround(code, options), expected);
+            assert.equal(iife.surround(code, options).code, expected);
         });
     });
 });


### PR DESCRIPTION
Added basic support for sourcemaps. 

There are cases in which the generated sourcemaps are off (for example, a file with leading empty lines and with the trim option selected), but I wanted to keep it simple to see if you were willing to accept the PR.