### PR TITLE
Add detectIife option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You can configure the following options:
 - [`bindThis`](#bindthis)
 - [`params`](#params)
 - [`args`](#args)
+- [`detectIife`](#detectIife)
 
 Here's an example specifying all available options:
 
@@ -132,6 +133,13 @@ An array of parameter names to be accepted by the IIFE. If the `args` option is 
 An array of argument names to be passed into the IIFE. If the `params` option is not specified, the parameters of the function will have the same names as the arguments passed.
 
 - **Default**: none
+
+
+### `detectIife`
+
+A boolean indicating whether to ignore files that already have an IIFE.
+
+- **Default**: false
 
 
 ## Source Maps

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/mariusschulz/gulp-iife",
   "dependencies": {
+    "acorn": "^5.1.2",
     "lodash": "^3.6.0",
     "source-map": "^0.5.3",
     "through2": "^2.0.0",

--- a/test/src/iife.js
+++ b/test/src/iife.js
@@ -226,5 +226,71 @@ var x = 1;
 
             assert.equal(iife.surround(code, options).code, expected);
         });
+
+        it("should do nothing if the file has an iife and \"detectIife\" is true", function() {
+            const expected = `;(function() {
+"use strict";
+
+var x = 1;
+}());
+`;
+            let options = {
+                detectIife: true
+            };
+
+            assert.equal(iife.surround(expected, options).code, expected);
+        });
+
+        it("should work if the file doesn't have an iife and \"detectIife\" is true", function () {
+            const expected = `;(function() {
+"use strict";
+
+var x = 1;
+}());
+`;
+            let options = {
+                detectIife: true
+            };
+
+            assert.equal(iife.surround(code, options).code, expected);
+        });
+
+        it("should add another iife if the file has an iife and \"detectIife\" is false", function () {
+            const code = `;(function() {
+"use strict";
+
+var x = 1;
+}());
+`;
+            const expected = `;(function() {
+"use strict";
+
+;(function() {
+"use strict";
+
+var x = 1;
+}());
+}());
+`;
+            let options = {
+                detectIife: false
+            };
+
+            assert.equal(iife.surround(code, options).code, expected);
+        });
+
+        it("should work iife if the file doesn't have an iife and \"detectIife\" is false", function () {
+            const expected = `;(function() {
+"use strict";
+
+var x = 1;
+}());
+`;
+            let options = {
+                detectIife: false
+            };
+
+            assert.equal(iife.surround(code, options).code, expected);
+        });
     });
 });


### PR DESCRIPTION
This should close #12.

There is at least one case this is not handling, and that I'm not sure if it should handle it. Files likes this:

```js
'use strict';

(function () {
  // code
})()
```

won't be recognized as IIFEs because of the `'use strict'`. It can be done, but I don't know if it should be ignored because it's not safe for concating, I think.