### PR TITLE
update lodash to 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/mariusschulz/gulp-iife",
   "dependencies": {
-    "lodash": "^3.6.0",
+    "lodash": "^4.17.11",
     "source-map": "^0.5.3",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.1"


### PR DESCRIPTION
fixes `npm audit` warnings about lodash vulnerabilities, there are no real breaking changes in lodash and `npm test` still succeeds